### PR TITLE
fix a build error caused by spec

### DIFF
--- a/spec.bs
+++ b/spec.bs
@@ -498,9 +498,9 @@ To <dfn>evaluate script</dfn> with given [=string=] <dfn for="evaluate script">|
 
 This specification defines two [=policy-controlled features=] identified by the string
 "<code><dfn noexport>join-ad-interest-group</dfn></code>", and
-"<code><dfn noexport>run-ad-auction</dfn></code>". Their [=default allowlists=] are `'self'`.
+"<code><dfn noexport>run-ad-auction</dfn></code>". Their [=policy-controlled feature/default allowlists=] are `'self'`.
 
-Note: In the Chromium implementation the [=default allowlists=] for both features are
+Note: In the Chromium implementation the [=policy-controlled feature/default allowlists=] for both features are
 temporarily set to `*` to ease testing.
 
 


### PR DESCRIPTION
The following build error starts showing up recently:

 _LINE ~499: No 'dfn' refs found for 'default allowlists' with for='None'.
      [=default allowlists=]_

Update [default allowlists=] to [=policy-controlled feature/default allowlists=]. Seems "policy-controlled feature/" part is required, after PR https://github.com/w3c/webappsec-permissions-policy/commit/e138f22fd9df0a2d5d517b98cfbdd82239da95cb.